### PR TITLE
Browser state save

### DIFF
--- a/properties.js
+++ b/properties.js
@@ -79,8 +79,8 @@ var self = {
       port : "8888"
     },
     dev : {
-      url : "dev.incntre.iu.edu" ,
-      port : "8888",
+      url : "unis.crest.iu.edu" ,
+      port : "8890",
       key: null,
       cert: null,
       use_ssl: false

--- a/public/js/exnode/DltFormController.js
+++ b/public/js/exnode/DltFormController.js
@@ -1,17 +1,32 @@
-function dltFormController($scope, $routeParams, $location, $rootScope, ExnodeService,$log,$filter,SocketService) {  
+function dltFormController($scope, $routeParams, $location, $rootScope, ExnodeService,$log,$filter,SocketService, $rootScope) {  
   // The usgs Model form
-  var usf = $scope.usgsform = {
-    startDate : "",
-    endDate : "",
-    sensorName : "" ,
-    searchModel : 'row',
-    cloud : 100 ,
-    isSeasonal : false,
-    latStart : "" , latEnd : "" ,
-    longStart : "" , longEnd: "",    
-    rowStart : "" , rowEnd : "",
-    pathStart : "", pathEnd : ""
-  };
+  
+  var now = new Date().valueOf()
+  var stateTimeOut = 1440000  //about a day
+  var usf = $scope.usgsform = loadForm()
+  
+  function loadForm() {
+    if (!$rootScope.landsatSearchState) {initForm();}
+    return $rootScope.landsatSearchState
+  }
+
+  function initForm() {
+    $rootScope.landsatSearchState = {
+      startDate : "",
+      endDate : "",
+      sensorName : "" ,
+      searchModel : 'row',
+      cloud : 100 ,
+      isSeasonal : false,
+      latStart : "" , latEnd : "" ,
+      longStart : "" , longEnd: "",    
+      rowStart : "" , rowEnd : "",
+      pathStart : "", pathEnd : ""
+    }
+  }
+
+
+
 
   function toMMFormat(date){
     return $filter('date')(date, "MM/dd/yyyy");
@@ -356,4 +371,5 @@ function shoppingCartController($scope, $routeParams, $location, $rootScope, Exn
       $scope.cartErrorMsg = "Unknown error - This is probably an issue with the EarthExplorer ";
     }
   });
+
 }

--- a/public/js/exnode/DltFormController.js
+++ b/public/js/exnode/DltFormController.js
@@ -1,17 +1,19 @@
 function dltFormController($scope, $routeParams, $location, $rootScope, ExnodeService,$log,$filter,SocketService, $rootScope) {  
-  // The usgs Model form
-  
-  var now = new Date().valueOf()
-  var stateTimeOut = 1440000  //about a day
   var usf = $scope.usgsform = loadForm()
   
+ 
+  
   function loadForm() {
+    var stateTimeOut = 1440000  //about a day
+    var now = new Date().valueOf()
     if (!$rootScope.landsatSearchState) {initForm();}
+    if ((now - $rootScope.landsatSearchState.timestamp) > stateTimeOut) {initForm();}
     return $rootScope.landsatSearchState
   }
 
   function initForm() {
     $rootScope.landsatSearchState = {
+      timestamp: new Date().valueOf(),
       startDate : "",
       endDate : "",
       sensorName : "" ,
@@ -27,6 +29,9 @@ function dltFormController($scope, $routeParams, $location, $rootScope, ExnodeSe
 
 
 
+  $scope.$on("$destroy", function() {
+    $rootScope.landsatSearchState.timestamp = new Date().valueOf()
+  })
 
   function toMMFormat(date){
     return $filter('date')(date, "MM/dd/yyyy");

--- a/public/js/exnode/ExnodeController.js
+++ b/public/js/exnode/ExnodeController.js
@@ -17,7 +17,7 @@ function getSchemaProperties(obj) {
  * public/js/exnode/
  * ExnodeController.js
  */
-function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeService,$log,SocketService, $route) {
+function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeService,$log,SocketService) {
   // Dangerous code
   // SocketService.emit('exnode_getAllChildren', {id : null});
   // SocketService.on('exnode_childFiles' , function(d){

--- a/public/js/exnode/ExnodeController.js
+++ b/public/js/exnode/ExnodeController.js
@@ -17,13 +17,18 @@ function getSchemaProperties(obj) {
  * public/js/exnode/
  * ExnodeController.js
  */
-function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeService,$log,SocketService) {
+function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeService,$log,SocketService, $route) {
   // Dangerous code
   // SocketService.emit('exnode_getAllChildren', {id : null});
   // SocketService.on('exnode_childFiles' , function(d){
   //   console.log("***********************",d);
   // });
   // The Exnode file browser 
+  //
+  //
+  //
+
+  console.log("Path on return: ", $rootScope.exnodeBrowserPath)
   $scope.fieldArr = [];      
   $scope.addField = function(){
     var x = {
@@ -134,8 +139,13 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
       jstr.get_node(info.id).state.loaded = false;
     }
   }
+
   function selectNodeGen(prefix) {
     return function(a,b){
+      //Store path for later restore
+      $scope.exnodeBrowserPath = b.node.parents.map(e=>e).reverse()
+      $scope.exnodeBrowserPath.push(b.node.id)
+
       var info = b.node.original;
       var selectedIds = $scope[prefix + 'selectedIds'] = $scope[prefix + 'selectedIds'] || {} ;
       if (!info.isFile) {
@@ -208,12 +218,8 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
     client_action([id], 'download');
   };
 
-  $scope.showExnodeMap = function(id) {
-    var parts = id.split("/")
-    id = parts[parts.length-1]
-    console.log("Showing exnode map for ", id)
-    $location.path("/exnode/"+id)
-  }
+
+
 
   $scope.downloadAll = function(){
     var arr = [];
@@ -241,5 +247,35 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
     dom.hide();
     dom.submit();
   };
+
+
+  $scope.restorePath = function() {
+    console.log("Restoring", $rootScope.exnodeBrowserPath)
+    if ($rootScope.exnodeBrowserPath) {
+      var tree = jQuery.jstree.reference(this)
+      var path = $rootScope.exnodeBrowserPath
+      tree.after_open = $scope.clearState
+      var loadNext = function(i) {
+        if (i <= path.length) {
+          tree.open_node(path[i])
+          tree.open_node(path[i], () => loadNext(i+1))
+        }
+      }
+      loadNext(1)
+    }
+  }
+
+  function savePath() {
+    $rootScope.exnodeBrowserPath = $scope.exnodeBrowserPath
+    console.log("Path on exit: ", $rootScope.exnodeBrowserPath)
+  }
+
+  $scope.showExnodeMap = function(id) {
+    savePath()
+    var parts = id.split("/")
+    id = parts[parts.length-1]
+    console.log("Showing exnode map for ", id)
+    $location.path("/exnode/"+id, true)
+  }
 }
 

--- a/public/js/exnode/ExnodeController.js
+++ b/public/js/exnode/ExnodeController.js
@@ -244,7 +244,6 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
   };
 
   $scope.showExnodeMap = function(id) {
-    savePath()
     var parts = id.split("/")
     id = parts[parts.length-1]
     console.log("Showing exnode map for ", id)

--- a/public/js/exnode/ExnodeController.js
+++ b/public/js/exnode/ExnodeController.js
@@ -17,7 +17,7 @@ function getSchemaProperties(obj) {
  * public/js/exnode/
  * ExnodeController.js
  */
-function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeService,$log,SocketService) {
+function exnodeController($scope, $routeParams, $location, ExnodeService,$log,SocketService) {
   // Dangerous code
   // SocketService.emit('exnode_getAllChildren', {id : null});
   // SocketService.on('exnode_childFiles' , function(d){
@@ -25,9 +25,6 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
   // });
   // The Exnode file browser 
   //
-  //
-  //
-
   $scope.fieldArr = [];      
   $scope.addField = function(){
     var x = {
@@ -140,9 +137,10 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
     }
   }
 
-  $scope.saveState = function(a,b) {
+  $scope.saveTreeState = function(a,b) {
     var jstr = jQuery.jstree.reference(this);
     jstr.save_state()
+
   }
 
   function selectNodeGen(prefix) {

--- a/public/js/exnode/ExnodeController.js
+++ b/public/js/exnode/ExnodeController.js
@@ -131,18 +131,26 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
   
   SocketService.on('exnode_childFiles', childFileHandler);
 
-  $scope.clearState = function(a,b){
+  $scope.invalidateLoaded = function(a,b){
     var info = b.node.original;
+    var jstr = jQuery.jstree.reference(this);
+    jstr.save_state()
     if (!info.isFile) {
-      var jstr = jQuery.jstree.reference(this);
       jstr.get_node(info.id).state.loaded = false;
     }
+  }
+
+  $scope.saveState = function(a,b) {
+    var jstr = jQuery.jstree.reference(this);
+    jstr.save_state()
   }
 
   function selectNodeGen(prefix) {
     return function(a,b){
       var info = b.node.original;
       var selectedIds = $scope[prefix + 'selectedIds'] = $scope[prefix + 'selectedIds'] || {} ;
+      var jstr = jQuery.jstree.reference(this);
+      jstr.save_state()
       if (!info.isFile) {
         // Do nothing
         return;
@@ -166,6 +174,8 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
   
   function unselectNodeGen(prefix){
     return function(a,b){
+      var jstr = jQuery.jstree.reference(this);
+      jstr.save_state()
       var info = b.node.original;
       if(!info.isFile) {
         // Do Nothing
@@ -244,6 +254,7 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
   };
 
   $scope.showExnodeMap = function(id) {
+
     var parts = id.split("/")
     id = parts[parts.length-1]
     console.log("Showing exnode map for ", id)

--- a/public/js/exnode/ExnodeController.js
+++ b/public/js/exnode/ExnodeController.js
@@ -28,7 +28,6 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
   //
   //
 
-  console.log("Path on return: ", $rootScope.exnodeBrowserPath)
   $scope.fieldArr = [];      
   $scope.addField = function(){
     var x = {
@@ -142,10 +141,6 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
 
   function selectNodeGen(prefix) {
     return function(a,b){
-      //Store path for later restore
-      $scope.exnodeBrowserPath = b.node.parents.map(e=>e).reverse()
-      $scope.exnodeBrowserPath.push(b.node.id)
-
       var info = b.node.original;
       var selectedIds = $scope[prefix + 'selectedIds'] = $scope[prefix + 'selectedIds'] || {} ;
       if (!info.isFile) {
@@ -247,28 +242,6 @@ function exnodeController($scope, $routeParams, $location, $rootScope, ExnodeSer
     dom.hide();
     dom.submit();
   };
-
-
-  $scope.restorePath = function() {
-    console.log("Restoring", $rootScope.exnodeBrowserPath)
-    if ($rootScope.exnodeBrowserPath) {
-      var tree = jQuery.jstree.reference(this)
-      var path = $rootScope.exnodeBrowserPath
-      tree.after_open = $scope.clearState
-      var loadNext = function(i) {
-        if (i <= path.length) {
-          tree.open_node(path[i])
-          tree.open_node(path[i], () => loadNext(i+1))
-        }
-      }
-      loadNext(1)
-    }
-  }
-
-  function savePath() {
-    $rootScope.exnodeBrowserPath = $scope.exnodeBrowserPath
-    console.log("Path on exit: ", $rootScope.exnodeBrowserPath)
-  }
 
   $scope.showExnodeMap = function(id) {
     savePath()

--- a/public/js/map/ExnodeMapController.js
+++ b/public/js/map/ExnodeMapController.js
@@ -31,8 +31,11 @@ function exnodeMapController($scope, $location, $http, UnisService, SocketServic
         extents = exnode.extents.map(function(e) {return {id: e.id, offset: e.offset, size: e.size, depot: parseLocation(e.mapping.read)}})
                                     .map(function(e) {e["xy"] = mapLocation(map, e.depot); return e})
                                     .sort((a,b) => a.depot.localeCompare(b.depot)) 
+      } else if (exnode.mode == "directory") {
+        errorMessage(map, "Exnode is for a directory, no extents")
+        return 
       } else {
-        extents = [{id: exnode.id, offset: exnode.offset, size: exnode.size, depot: parseLocation(e.mapping.read)}]
+        extents = [{id: exnode.id, offset: exnode.offset, size: exnode.size, depot: parseLocation(exnode.mapping.read)}]
       }
       
       var cells = range(0, 500).map(function(e) {return {depots:new Set(), exnodes:[]}})
@@ -57,13 +60,16 @@ function exnodeMapController($scope, $location, $http, UnisService, SocketServic
       exnodeStats(map, exnode, cells, 970, 100)
       legend(map, exnode, extents, fill, 970, 230)
     } else {
-      map.svg.append("text")
-          .attr("fill", "red")
-          .attr("transform", "translate(300,10)")
-          .text("Error: Exnode not found or is empty")
+      errorMessage(map, "Error: Exnode not found or is empty")
     }
   }
 
+  function errorMessage(map, message) {
+      map.svg.append("text")
+          .attr("fill", "red")
+          .attr("transform", "translate(300,10)")
+          .text(message)
+  }
 
   function spokeExtents(svg, rootSize, extents, fill) {
     var unique_depot_by_location = extents.reduce(function(acc, e) {

--- a/views/views/browser.html
+++ b/views/views/browser.html
@@ -8,7 +8,7 @@
                         <!-- <js-tree tree-events="select_node:nodeSelected" tree-data="json" tree-src="/views/filetree.json"  tree-plugins="checkbox"></js-tree> -->
                         <js-tree tree-events="loaded:restorePath;after_open:clearState;check_node:nodeSelected;uncheck_node:nodeUnselected;uncheck_all:uncheckAll;check_all:checkAll"   
                                  tree-checkbox="{ tie_selection : false , three_state: false}"
-                                 tree-plugins="checkbox"
+                                 tree-plugins="checkbox,state"
                                  tree-ajax="/api/fileTree"></js-tree>
                     </div>
                     <div class="col-md-7 file-viewer">

--- a/views/views/browser.html
+++ b/views/views/browser.html
@@ -6,7 +6,7 @@
                 <div class="row top5">
                     <div class="col-md-5 tree-browser">
                         <!-- <js-tree tree-events="select_node:nodeSelected" tree-data="json" tree-src="/views/filetree.json"  tree-plugins="checkbox"></js-tree> -->
-                        <js-tree tree-events="after_open:clearState;check_node:nodeSelected;uncheck_node:nodeUnselected;uncheck_all:uncheckAll;check_all:checkAll"   
+                        <js-tree tree-events="loaded:restorePath;after_open:clearState;check_node:nodeSelected;uncheck_node:nodeUnselected;uncheck_all:uncheckAll;check_all:checkAll"   
                                  tree-checkbox="{ tie_selection : false , three_state: false}"
                                  tree-plugins="checkbox"
                                  tree-ajax="/api/fileTree"></js-tree>

--- a/views/views/browser.html
+++ b/views/views/browser.html
@@ -6,7 +6,7 @@
                 <div class="row top5">
                     <div class="col-md-5 tree-browser">
                         <!-- <js-tree tree-events="select_node:nodeSelected" tree-data="json" tree-src="/views/filetree.json"  tree-plugins="checkbox"></js-tree> -->
-                        <js-tree tree-events="loaded:restorePath;after_open:clearState;check_node:nodeSelected;uncheck_node:nodeUnselected;uncheck_all:uncheckAll;check_all:checkAll"   
+                        <js-tree tree-events="after_open:clearState;check_node:nodeSelected;uncheck_node:nodeUnselected;uncheck_all:uncheckAll;check_all:checkAll"   
                                  tree-checkbox="{ tie_selection : false , three_state: false}"
                                  tree-plugins="checkbox,state"
                                  tree-ajax="/api/fileTree"></js-tree>

--- a/views/views/browser.html
+++ b/views/views/browser.html
@@ -6,7 +6,7 @@
                 <div class="row top5">
                     <div class="col-md-5 tree-browser">
                         <!-- <js-tree tree-events="select_node:nodeSelected" tree-data="json" tree-src="/views/filetree.json"  tree-plugins="checkbox"></js-tree> -->
-                        <js-tree tree-events="after_open:invalidateLoad;after_close:saveState;check_node:nodeSelected;uncheck_node:nodeUnselected;uncheck_all:uncheckAll;check_all:checkAll"   
+                        <js-tree tree-events="after_open:invalidateLoad;after_close:saveTreeState;check_node:nodeSelected;uncheck_node:nodeUnselected;uncheck_all:uncheckAll;check_all:checkAll"   
                                  tree-ajax="/api/fileTree"
                                  tree-plugins="checkbox,state"
                                  tree-checkbox="{ tie_selection : false , three_state: false}"
@@ -47,6 +47,7 @@
                     </div>
                 </div>
             </tab>
+
             <tab heading="Exnode Search"  ng-controller="DltFormController">
                 <form class="form-horizontal top5" id="searchForm" ng-submit="searchExnodes()">
                     <div class="form-group"  ng-repeat="field in fieldArr">
@@ -126,6 +127,7 @@
                     </div>
                 </div>               
             </tab>     
+
             <tab heading="Landsat Search"  ng-controller="DltFormController">
                 <form class="form-horizontal top5 usgsform" ng-submit="submitUsgsForm()">
                     <div class="row">
@@ -344,6 +346,7 @@
                  </div> -->  
                 </form>
             </tab>
+
             <tab heading="USGS Shopping Cart" ng-controller="ShoppingCartController">
                 <div class="row">                            
                     <div ng-if="isShoppingCartLoading" style=" padding: 10px; margin: 10px 0;background-color: rgba(200,200,200,0.3);">

--- a/views/views/browser.html
+++ b/views/views/browser.html
@@ -6,10 +6,12 @@
                 <div class="row top5">
                     <div class="col-md-5 tree-browser">
                         <!-- <js-tree tree-events="select_node:nodeSelected" tree-data="json" tree-src="/views/filetree.json"  tree-plugins="checkbox"></js-tree> -->
-                        <js-tree tree-events="after_open:clearState;check_node:nodeSelected;uncheck_node:nodeUnselected;uncheck_all:uncheckAll;check_all:checkAll"   
-                                 tree-checkbox="{ tie_selection : false , three_state: false}"
+                        <js-tree tree-events="after_open:invalidateLoad;after_close:saveState;check_node:nodeSelected;uncheck_node:nodeUnselected;uncheck_all:uncheckAll;check_all:checkAll"   
+                                 tree-ajax="/api/fileTree"
                                  tree-plugins="checkbox,state"
-                                 tree-ajax="/api/fileTree"></js-tree>
+                                 tree-checkbox="{ tie_selection : false , three_state: false}"
+                                 tree-state="{key: 'exnode-browser', ttl: 1440000}">
+                        </js-tree>
                     </div>
                     <div class="col-md-7 file-viewer">
                         <div>


### PR DESCRIPTION
Restores browser tree state on tab entry/exit, accomplished with the jstree "state" plugin.  

Only does the browser tree because (in general) angular tab state appears hard to save/restore (too many plugins, so its always a custom deal).  This handles several common cases.

Also includes better error handling on the exnode vis in case a request to display a directory exnode is made.
